### PR TITLE
fix: optimistic db write batch

### DIFF
--- a/src/transactions/optimistic_transaction_db.rs
+++ b/src/transactions/optimistic_transaction_db.rs
@@ -274,7 +274,7 @@ impl<T: ThreadMode> OptimisticTransactionDB<T> {
     ) -> Result<(), Error> {
         unsafe {
             ffi_try!(ffi::rocksdb_optimistictransactiondb_write(
-                self.inner.inner(),
+                self.inner.db,
                 writeopts.inner,
                 batch.inner
             ));

--- a/src/transactions/optimistic_transaction_db.rs
+++ b/src/transactions/optimistic_transaction_db.rs
@@ -273,7 +273,7 @@ impl<T: ThreadMode> OptimisticTransactionDB<T> {
         writeopts: &WriteOptions,
     ) -> Result<(), Error> {
         unsafe {
-            ffi_try!(ffi::rocksdb_write(
+            ffi_try!(ffi::rocksdb_optimistictransactiondb_write(
                 self.inner.inner(),
                 writeopts.inner,
                 batch.inner


### PR DESCRIPTION
I am not completely sure of myself here. I was surprised you were using rocksdb_write instead of rocksdb_optimistictransactiondb_write, but I must admit I don't know much of the difference.